### PR TITLE
feat(repoitem): link repoitems

### DIFF
--- a/packages/web/components/RepoItem/RepoItem.tsx
+++ b/packages/web/components/RepoItem/RepoItem.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Typography,
+  Button,
+  Card,
+  CardHeader,
+  CardContent,
+  CardActions,
+} from 'javascript-af-ui';
+import Link from 'next/link';
+import styled from 'styled-components';
+
+const A = styled.a`
+  text-decoration: none;
+  cursor: pointer;
+`;
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  image?: string;
+  title: string;
+  description: string;
+  slug: string;
+}
+
+export const RepoItem: React.SFC<Props> = props => {
+  const { title, description, slug, children, ...others } = props;
+  return (
+    <Card
+      elevation={2}
+      style={{
+        maxWidth: '300px',
+      }}
+    >
+      <Link href={`/r/${slug}`}>
+        <A>
+          <CardHeader title={title} />
+        </A>
+      </Link>
+      <CardContent>
+        <Typography>{description}</Typography>
+      </CardContent>
+      <CardActions>
+        <Link href={`/r/${slug}`}>
+          <Button>View</Button>
+        </Link>
+      </CardActions>
+    </Card>
+  );
+};

--- a/packages/web/components/RepoItem/RepoItem.tsx
+++ b/packages/web/components/RepoItem/RepoItem.tsx
@@ -19,19 +19,23 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   image?: string;
   title: string;
   description: string;
-  slug: string;
+  githubUser: string;
+  githubRepo: string;
 }
 
 export const RepoItem: React.SFC<Props> = props => {
-  const { title, description, slug, children, ...others } = props;
+  const {
+    title,
+    description,
+    githubUser,
+    githubRepo,
+    children,
+    ...others
+  } = props;
+
   return (
-    <Card
-      elevation={2}
-      style={{
-        maxWidth: '300px',
-      }}
-    >
-      <Link href={`/r/${slug}`}>
+    <Card elevation={2} style={{ maxWidth: '300px' }}>
+      <Link href={`/r/${githubUser}/${githubRepo}`}>
         <A>
           <CardHeader title={title} />
         </A>
@@ -40,7 +44,7 @@ export const RepoItem: React.SFC<Props> = props => {
         <Typography>{description}</Typography>
       </CardContent>
       <CardActions>
-        <Link href={`/r/${slug}`}>
+        <Link href={`/r/${githubUser}/${githubRepo}`}>
           <Button>View</Button>
         </Link>
       </CardActions>

--- a/packages/web/components/RepoItem/index.ts
+++ b/packages/web/components/RepoItem/index.ts
@@ -1,0 +1,1 @@
+export * from './RepoItem';

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -113,7 +113,8 @@ const Index: React.SFC = () => {
                         key={item.id}
                         title={item.githubName}
                         description={item.description}
-                        slug={item.slug}
+                        githubUser={item.githubOwner}
+                        githubRepo={item.githubName}
                       />
                     ))}
                   </CardHorizontalScroller>

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,23 +1,16 @@
 import * as React from 'react';
-import {
-  Button,
-  Typography,
-  CardHorizontalScroller,
-  Card,
-  CardHeader,
-  CardContent,
-  CardActions,
-} from 'javascript-af-ui';
-import Layout from '../components/Layouts';
+import { Typography, CardHorizontalScroller } from 'javascript-af-ui';
 import {
   RepositoriesController,
   NewsItemsController,
   TalksController,
 } from '@jsaf/controller';
-import { HeroItem } from '../components/HeroItem';
 import shuffle from 'lodash.shuffle';
-import { HERO_COLORS } from '../constants';
 import styled from 'styled-components';
+import { HERO_COLORS } from '../constants';
+import Layout from '../components/Layouts';
+import { HeroItem } from '../components/HeroItem';
+import { RepoItem } from '../components/RepoItem';
 import { NewsItem } from '../components/NewsItem';
 import { TalkItem } from '../components/TalkItem';
 
@@ -116,21 +109,12 @@ const Index: React.SFC = () => {
                 return (
                   <CardHorizontalScroller>
                     {data.map(item => (
-                      <Card
+                      <RepoItem
                         key={item.id}
-                        elevation={2}
-                        style={{
-                          maxWidth: '300px',
-                        }}
-                      >
-                        <CardHeader title={item.githubName} />
-                        <CardContent>
-                          <Typography>{item.description}</Typography>
-                        </CardContent>
-                        <CardActions>
-                          <Button>View</Button>
-                        </CardActions>
-                      </Card>
+                        title={item.githubName}
+                        description={item.description}
+                        slug={item.slug}
+                      />
                     ))}
                   </CardHorizontalScroller>
                 );


### PR DESCRIPTION
re #16 	
PR, because, hacktoberfest 🎃 	

created RepoItem.tsx to follow conventions already in place.
This leads to a lot of duplicate code right now, but there are (already) subtle differences. As time goes by they will become even more different.